### PR TITLE
Update deps to support ruby 3

### DIFF
--- a/hanami-webconsole.gemspec
+++ b/hanami-webconsole.gemspec
@@ -23,8 +23,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "sassc", "~> 2.0"
   spec.add_dependency "better_errors", "~> 2.4"
-  spec.add_dependency "binding_of_caller", "~> 0.8"
+  spec.add_dependency "binding_of_caller", "~> 1.0"
 
   spec.add_development_dependency "bundler", ">= 1.16", "< 3"
   spec.add_development_dependency "rake", "~> 12.0"

--- a/lib/hanami/webconsole/plugin.rb
+++ b/lib/hanami/webconsole/plugin.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "sassc"
 require "better_errors"
 require "binding_of_caller"
 


### PR DESCRIPTION
### Background

binding_of_caller gem does not support ruby 3 in version `0.8`. Also, there is missing `sassc` gem that is required by better errors to work properly.

### Design

1. Update `binding_of_caller` to 1.0.0
2. Add `sassc` dependency, so our services do not need to require and install it on their own.